### PR TITLE
Add chromium driver to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM --platform=$TARGETPLATFORM ruby:3.2.2-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     chromium \
+    chromium-driver \
     libpq-dev \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- install `chromium-driver` so the container has the matching driver

## Testing
- `docker build -t test-runner .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d860aa790832d8076333d22b7fa7b