### PR TITLE
Add Watir example and README notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,23 @@ docker run -it --rm -v ~/lets-qa/acceptance:/app test-runner:amd64 bash
 This command launches the container with the current working directory set
 to `/app`, where your tests are mounted. From there you can run any
 commands you need, such as `bundle exec cucumber` or `bundle exec rspec`.
+
+## Testing Watir
+
+You can quickly verify that Watir is working inside the container by running a small script.
+
+```ruby
+# test_browser.rb
+require 'watir'
+browser = Watir::Browser.new(:chrome, headless: true)
+browser.goto('https://example.com')
+puts browser.title
+browser.close
+```
+
+Run the script inside the container with:
+
+```bash
+bundle exec ruby test_browser.rb
+```
+

--- a/test_browser.rb
+++ b/test_browser.rb
@@ -1,0 +1,6 @@
+require 'watir'
+
+browser = Watir::Browser.new(:chrome, headless: true)
+browser.goto('https://example.com')
+puts browser.title
+browser.close


### PR DESCRIPTION
## Summary
- document a simple Watir test in README
- add a small Ruby sample for Watir

## Testing
- `bundle exec ruby test_browser.rb` *(fails: Could not find gem 'cucumber' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_687d86164f6c832d8490998a02a03449