### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arm64-docker-image.yml
+++ b/.github/workflows/arm64-docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lets-qa/test-runner/security/code-scanning/2](https://github.com/lets-qa/test-runner/security/code-scanning/2)

The best way to fix the problem is to explicitly specify the least permissions required for the job by adding a `permissions` block to the workflow. Since the job only checks out code and builds a Docker image (no steps that interact with PRs, issues, or write to the repository), the minimal permission needed is `contents: read`. This should be set either at the workflow root (to apply to all jobs unless overridden) or to each job that doesn't already specify permissions.

The required edit is to add the following at the root level, underneath the `name:` and before the `on:` block in `.github/workflows/arm64-docker-image.yml`:
```yaml
permissions:
  contents: read
```
This requires no additional imports, definitions, or further changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
